### PR TITLE
Mesh parent scale fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.vs/AgXUnity/v14
 /AgXUnityEditor/obj/Debug
 /output
+/AgXUnityEditor/obj/Release

--- a/AgXUnity/AgXUnity.csproj
+++ b/AgXUnity/AgXUnity.csproj
@@ -60,7 +60,8 @@
       <HintPath>..\..\trunk\installed\bin\x64\agxDotNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="UnityEngine">
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>

--- a/AgXUnity/Attributes.cs
+++ b/AgXUnity/Attributes.cs
@@ -47,6 +47,9 @@ namespace AgXUnity
   [System.AttributeUsage( System.AttributeTargets.Method, AllowMultiple = false )]
   public class InvokableInInspector : System.Attribute
   {
+    public InvokableInInspector( string label = "" ) { Label = label; }
+
+    public string Label = "";
   }
 
   /// <summary>

--- a/AgXUnity/Collide/Box.cs
+++ b/AgXUnity/Collide/Box.cs
@@ -28,7 +28,7 @@ namespace AgXUnity.Collide
         m_halfExtents = value.ClampedElementsAbove( MinimumLength );
 
         if ( Native != null )
-          Native.setHalfExtents( m_halfExtents.AsVec3() );
+          Native.setHalfExtents( m_halfExtents.ToVec3() );
 
         SizeUpdated();
       }
@@ -54,7 +54,7 @@ namespace AgXUnity.Collide
     /// <returns>Native box object.</returns>
     protected override agxCollide.Shape CreateNative()
     {
-      return new agxCollide.Box( HalfExtents.AsVec3() );
+      return new agxCollide.Box( HalfExtents.ToVec3() );
     }
   }
 }

--- a/AgXUnity/Collide/Capsule.cs
+++ b/AgXUnity/Collide/Capsule.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 
 namespace AgXUnity.Collide
 {
+  // TODO: Picking capsules doesn't work.
+
   /// <summary>
   /// Capsule shape object given radius and height.
   /// </summary>

--- a/AgXUnity/Collide/Plane.cs
+++ b/AgXUnity/Collide/Plane.cs
@@ -29,7 +29,7 @@ namespace AgXUnity.Collide
     /// <returns></returns>
     protected override agxCollide.Shape CreateNative()
     {
-      return new agxCollide.Plane( transform.up.AsVec3(), 0 );
+      return new agxCollide.Plane( transform.up.ToHandedVec3(), 0 );
     }
   }
 }

--- a/AgXUnity/Constraint.cs
+++ b/AgXUnity/Constraint.cs
@@ -714,17 +714,17 @@ namespace AgXUnity
       agx.Frame f2 = new agx.Frame();
 
       if ( m_frames[ 0 ].transform != rb1.transform ) {
-        f1.setLocalTranslate( ( rb1.transform.InverseTransformPoint( m_frames[ 0 ].transform.position ) ).AsVec3() );
-        f1.setLocalRotate( ( Quaternion.Inverse( rb1.transform.rotation ) * m_frames[ 0 ].transform.rotation ).AsQuat() );
+        f1.setLocalTranslate( ( rb1.transform.InverseTransformPoint( m_frames[ 0 ].transform.position ) ).ToHandedVec3() );
+        f1.setLocalRotate( ( Quaternion.Inverse( rb1.transform.rotation ) * m_frames[ 0 ].transform.rotation ).ToHandedQuat() );
       }
 
       if ( rb2 != null && m_frames[ 1 ].transform != rb2.transform ) {
-        f2.setLocalTranslate( ( rb2.transform.InverseTransformPoint( m_frames[ 1 ].transform.position ).AsVec3() ) );
-        f2.setLocalRotate( ( Quaternion.Inverse( rb2.transform.rotation ) * m_frames[ 1 ].transform.rotation ).AsQuat() );
+        f2.setLocalTranslate( ( rb2.transform.InverseTransformPoint( m_frames[ 1 ].transform.position ).ToHandedVec3() ) );
+        f2.setLocalRotate( ( Quaternion.Inverse( rb2.transform.rotation ) * m_frames[ 1 ].transform.rotation ).ToHandedQuat() );
       }
       else {
-        f2.setLocalTranslate( m_frames[ 1 ].transform.position.AsVec3() );
-        f2.setLocalRotate( m_frames[ 1 ].transform.rotation.AsQuat() );
+        f2.setLocalTranslate( m_frames[ 1 ].transform.position.ToHandedVec3() );
+        f2.setLocalRotate( m_frames[ 1 ].transform.rotation.ToHandedQuat() );
       }
 
       m_constraint = Instantiate( rb1.Native, f1, rb2 ? rb2.Native : null, f2 );
@@ -751,11 +751,11 @@ namespace AgXUnity
       agx.Frame f1 = m_constraint.getAttachment( m_constraint.getBodyAt( 0 ) ).getFrame();
       agx.Frame f2 = m_constraint.getAttachment( m_constraint.getBodyAt( 1 ) ).getFrame();
 
-      f1.setLocalTranslate( m_frames[ 0 ].transform.localPosition.AsVec3() );
-      f1.setLocalRotate( m_frames[ 0 ].transform.localRotation.AsQuat() );
+      f1.setLocalTranslate( m_frames[ 0 ].transform.localPosition.ToHandedVec3() );
+      f1.setLocalRotate( m_frames[ 0 ].transform.localRotation.ToHandedQuat() );
 
-      f2.setLocalTranslate( m_frames[ 1 ].transform.localPosition.AsVec3() );
-      f2.setLocalRotate( m_frames[ 1 ].transform.localRotation.AsQuat() );
+      f2.setLocalTranslate( m_frames[ 1 ].transform.localPosition.ToHandedVec3() );
+      f2.setLocalRotate( m_frames[ 1 ].transform.localRotation.ToHandedQuat() );
 
       // If we've an animator object attached to this constraint,
       // synchronize properties.

--- a/AgXUnity/MassProperties.cs
+++ b/AgXUnity/MassProperties.cs
@@ -55,7 +55,7 @@ namespace AgXUnity
         m_inertiaDiagonal = value;
         agx.RigidBody native = GetNative();
         if ( native != null )
-          native.getMassProperties().setInertiaTensor( m_inertiaDiagonal.Value.AsVec3() );
+          native.getMassProperties().setInertiaTensor( m_inertiaDiagonal.Value.ToVec3() );
       }
     }
 
@@ -70,7 +70,7 @@ namespace AgXUnity
         m_massCoefficients = value;
         agx.RigidBody native = GetNative();
         if ( native != null )
-          native.getMassProperties().setMassCoefficients( m_massCoefficients.AsVec3() );
+          native.getMassProperties().setMassCoefficients( m_massCoefficients.ToVec3() );
       }
     }
 
@@ -85,7 +85,7 @@ namespace AgXUnity
         m_inertiaCoefficients = value;
         agx.RigidBody native = GetNative();
         if ( native != null )
-          native.getMassProperties().setInertiaTensorCoefficients( m_inertiaCoefficients.AsVec3() );
+          native.getMassProperties().setInertiaTensorCoefficients( m_inertiaCoefficients.ToVec3() );
       }
     }
 
@@ -95,7 +95,7 @@ namespace AgXUnity
         return;
 
       Mass.DefaultValue = Convert.ToSingle( nativeRb.getMassProperties().getMass() );
-      InertiaDiagonal.DefaultValue = nativeRb.getMassProperties().getPrincipalInertiae().AsVector3();
+      InertiaDiagonal.DefaultValue = nativeRb.getMassProperties().getPrincipalInertiae().ToVector3();
     }
 
     protected override bool Initialize()

--- a/AgXUnity/Rendering/DebugRenderManager.cs
+++ b/AgXUnity/Rendering/DebugRenderManager.cs
@@ -114,10 +114,14 @@ namespace AgXUnity.Rendering
       if ( data.Node == null )
         return;
 
-      data.Node.hideFlags = HideFlags.DontSave;
+      data.Node.transform.localScale                            = shape.GetScale();
+      data.Node.transform.position                              = shape.transform.position;
+      data.Node.transform.rotation                              = shape.transform.rotation;
+
+      data.Node.hideFlags                                       = HideFlags.DontSave;
       data.Node.GetOrCreateComponent<OnSelectionProxy>().Target = shape.gameObject;
 
-      if ( data.Node && data.Node.transform.parent != gameObject.transform )
+      if ( data.Node != null && data.Node.transform.parent != gameObject.transform )
         gameObject.AddChild( data.Node );
     }
   }

--- a/AgXUnity/Rendering/ShapeDebugRenderData.cs
+++ b/AgXUnity/Rendering/ShapeDebugRenderData.cs
@@ -124,27 +124,32 @@ namespace AgXUnity.Rendering
 
     private void RescaleRenderedMesh( Collide.Mesh mesh, MeshFilter filter )
     {
-      if ( mesh.SourceObject == null )
+      UnityEngine.Mesh source = mesh.SourceObject;
+      if ( source == null )
         throw new AgXUnity.Exception( "Source object is null during rescale." );
 
       Vector3[] vertices = filter.sharedMesh.vertices;
-      if ( vertices.Length == 0 )
-        vertices = new Vector3[ mesh.SourceObject.vertexCount ];
+      if ( vertices == null || vertices.Length == 0 )
+        vertices = new Vector3[ source.vertexCount ];
 
       int[] triangles = filter.sharedMesh.triangles;
       if ( triangles == null || triangles.Length == 0 )
-        triangles = (int[])mesh.SourceObject.triangles.Clone();
+        triangles = (int[])source.triangles.Clone();
 
-      if ( vertices.Length != mesh.SourceObject.vertexCount )
+      if ( vertices.Length != source.vertexCount )
         throw new AgXUnity.Exception( "Shape debug render mesh mismatch." );
 
-      Matrix4x4 scaledToWorld = mesh.transform.localToWorldMatrix;
+      Matrix4x4 scaledToWorld  = mesh.transform.localToWorldMatrix;
+      Vector3[] sourceVertices = mesh.SourceObject.vertices;
+
+      // Transforms each vertex from local to world given scales, then
+      // transfroms each vertex back to local again - unscaled.
       for ( int i = 0; i < vertices.Length; ++i ) {
-        Vector3 worldVertex = scaledToWorld * mesh.SourceObject.vertices[ i ];
-        vertices[ i ] = mesh.transform.InverseTransformDirection( worldVertex );
+        Vector3 worldVertex = scaledToWorld * sourceVertices[ i ];
+        vertices[ i ]       = mesh.transform.InverseTransformDirection( worldVertex );
       }
 
-      filter.sharedMesh.vertices = vertices;
+      filter.sharedMesh.vertices  = vertices;
       filter.sharedMesh.triangles = triangles;
 
       filter.sharedMesh.RecalculateBounds();

--- a/AgXUnity/Rendering/ShapeDebugRenderData.cs
+++ b/AgXUnity/Rendering/ShapeDebugRenderData.cs
@@ -33,6 +33,9 @@ namespace AgXUnity.Rendering
     /// <returns>The Collide.Shape component.</returns>
     public Shape GetShape() { return GetComponent<Shape>(); }
 
+    [SerializeField]
+    private Vector3 m_storedLossyScale = Vector3.one;
+
     /// <summary>
     /// Creates debug rendering node (if not already created) and
     /// synchronizes the transform.
@@ -42,10 +45,10 @@ namespace AgXUnity.Rendering
       try {
         TryInitialize();
 
-        Shape shape               = GetShape();
-        Node.transform.localScale = shape.GetScale();
-        Node.transform.position   = shape.transform.position;
-        Node.transform.rotation   = shape.transform.rotation;
+        if ( IsMesh && m_storedLossyScale != transform.lossyScale ) {
+          RescaleRenderedMesh( GetShape() as Collide.Mesh, Node.GetComponent<MeshFilter>() );
+          m_storedLossyScale = transform.lossyScale;
+        }
       }
       catch ( System.Exception ) {
       }
@@ -101,8 +104,12 @@ namespace AgXUnity.Rendering
       MeshRenderer renderer = meshData.AddComponent<MeshRenderer>();
       MeshFilter filter = meshData.AddComponent<MeshFilter>();
 
+      filter.sharedMesh = new UnityEngine.Mesh();
+
+      RescaleRenderedMesh( mesh, filter );
+
       renderer.sharedMaterial = Resources.Load<UnityEngine.Material>( "Materials/DebugRendererMaterial" );
-      filter.sharedMesh = mesh.SourceObject;
+      m_storedLossyScale = mesh.transform.lossyScale;
 
       return meshData;
     }
@@ -113,6 +120,35 @@ namespace AgXUnity.Rendering
     private GameObject InitializeHeightField( HeightField hf )
     {
       return new GameObject( "HeightFieldData" );
+    }
+
+    private void RescaleRenderedMesh( Collide.Mesh mesh, MeshFilter filter )
+    {
+      if ( mesh.SourceObject == null )
+        throw new AgXUnity.Exception( "Source object is null during rescale." );
+
+      Vector3[] vertices = filter.sharedMesh.vertices;
+      if ( vertices.Length == 0 )
+        vertices = new Vector3[ mesh.SourceObject.vertexCount ];
+
+      int[] triangles = filter.sharedMesh.triangles;
+      if ( triangles == null || triangles.Length == 0 )
+        triangles = (int[])mesh.SourceObject.triangles.Clone();
+
+      if ( vertices.Length != mesh.SourceObject.vertexCount )
+        throw new AgXUnity.Exception( "Shape debug render mesh mismatch." );
+
+      Matrix4x4 scaledToWorld = mesh.transform.localToWorldMatrix;
+      for ( int i = 0; i < vertices.Length; ++i ) {
+        Vector3 worldVertex = scaledToWorld * mesh.SourceObject.vertices[ i ];
+        vertices[ i ] = mesh.transform.InverseTransformDirection( worldVertex );
+      }
+
+      filter.sharedMesh.vertices = vertices;
+      filter.sharedMesh.triangles = triangles;
+
+      filter.sharedMesh.RecalculateBounds();
+      filter.sharedMesh.RecalculateNormals();
     }
   }
 }

--- a/AgXUnity/Rendering/WireRenderer.cs
+++ b/AgXUnity/Rendering/WireRenderer.cs
@@ -188,7 +188,7 @@ namespace AgXUnity.Rendering
       agxWire.RenderIterator it    = wire.Native.getRenderBeginIterator();
       agxWire.RenderIterator endIt = wire.Native.getRenderEndIterator();
       while ( !it.EqualWith( endIt ) ) {
-        positions.Add( it.get().getWorldPosition().AsVector3() );
+        positions.Add( it.get().getWorldPosition().ToHandedVector3() );
         it.inc();
       }
 

--- a/AgXUnity/Wire.cs
+++ b/AgXUnity/Wire.cs
@@ -170,8 +170,8 @@ namespace AgXUnity
         // We don't know if the parent is the rigid body.
         // It could be a mesh, or some other object.
         agx.Vec3 point = rb != null ?
-                          rb.transform.InverseTransformPoint( WorldPosition ).AsVec3() :
-                          WorldPosition.AsVec3();
+                          rb.transform.InverseTransformPoint( WorldPosition ).ToHandedVec3() :
+                          WorldPosition.ToHandedVec3();
 
         agx.RigidBody nativeRb = rb != null ? rb.Native : null;
         if ( Type == NodeType.BodyFixedNode )
@@ -184,7 +184,7 @@ namespace AgXUnity
         else if ( Type == NodeType.EyeNode )
           return new agxWire.EyeNode( nativeRb, point );
         else if ( Type == NodeType.ContactNode )
-          return new agxWire.ContactNode( shape.NativeGeometry, shape.transform.InverseTransformPoint( WorldPosition ).AsVec3() );
+          return new agxWire.ContactNode( shape.NativeGeometry, shape.transform.InverseTransformPoint( WorldPosition ).ToHandedVec3() );
         else if ( Type == NodeType.WinchNode ) {
           if ( m_winch == null )
             throw new AgXUnity.Exception( "No reference to a wire winch component in the winch node." );

--- a/AgXUnity/WireWinch.cs
+++ b/AgXUnity/WireWinch.cs
@@ -107,7 +107,7 @@ namespace AgXUnity
     protected override bool Initialize()
     {
       RigidBody rb = Parent.GetInitializedComponentInParent<RigidBody>();
-      Native = new agxWire.WireWinchController( rb != null ? rb.Native : null, LocalPosition.AsVec3(), LocalDirection.AsVec3() );
+      Native = new agxWire.WireWinchController( rb != null ? rb.Native : null, LocalPosition.ToHandedVec3(), LocalDirection.ToHandedVec3() );
 
       return base.Initialize();
     }

--- a/AgXUnityEditor/BaseEditor.cs
+++ b/AgXUnityEditor/BaseEditor.cs
@@ -212,8 +212,15 @@ namespace AgXUnityEditor
       if ( methodInfo == null )
         return false;
 
+      object[] attributes = methodInfo.GetCustomAttributes( typeof( InvokableInInspector ), false );
+      GUIContent label = null;
+      if ( attributes.Length > 0 && ( attributes[ 0 ] as InvokableInInspector ).Label != "" )
+        label = Utils.GUIHelper.MakeLabel( ( attributes[ 0 ] as InvokableInInspector ).Label );
+      else
+        label = MakeLabel( methodInfo );
+
       bool invoked = false;
-      if ( GUILayout.Button( MakeLabel( methodInfo ), Utils.GUIHelper.EditorSkin.button, new GUILayoutOption[]{} ) ) {
+      if ( GUILayout.Button( label, Utils.GUIHelper.EditorSkin.button, new GUILayoutOption[]{} ) ) {
         methodInfo.Invoke( target, new object[] { } );
         invoked = true;
       }


### PR DESCRIPTION
Handling conversion from/to Unity left handed coordinate system.

Handling scale. GameObject scale doesn't affect the size of our native shapes because of skewing/shearing. Collide.Mesh fully supports non-uniform scale and skewing/shearing.

The debug rendering is more reliable.
