### PR TITLE
Primitive shape tool

### DIFF
--- a/AgXUnity/AgXUnity.csproj
+++ b/AgXUnity/AgXUnity.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Collide\Mesh.cs" />
     <Compile Include="Collide\Plane.cs" />
     <Compile Include="Collide\Shape.cs" />
+    <Compile Include="Collide\ShapeUtils.cs" />
     <Compile Include="Collide\Sphere.cs" />
     <Compile Include="CollisionGroups.cs" />
     <Compile Include="CollisionGroupsManager.cs" />

--- a/AgXUnity/Collide/Mesh.cs
+++ b/AgXUnity/Collide/Mesh.cs
@@ -35,14 +35,16 @@ namespace AgXUnity.Collide
           if ( data != null )
             GameObject.DestroyImmediate( data.Node );
           m_sourceObject = null;
-          SizeUpdated();
         }
 
         // New source.
         if ( m_sourceObject == null ) {
           m_sourceObject = value;
-          // Create debug rendering data.
-          SizeUpdated();
+
+          // Instead of calling SizeUpdated we have to make sure
+          // a complete new instance of the debug render object
+          // is created (i.e., not only update scale if node exist).
+          Rendering.DebugRenderManager.HandleMeshSource( this );
         }
       }
     }

--- a/AgXUnity/Collide/Shape.cs
+++ b/AgXUnity/Collide/Shape.cs
@@ -12,6 +12,11 @@ namespace AgXUnity.Collide
   public abstract class Shape : ScriptComponent
   {
     /// <summary>
+    /// Utils (resize etc.) utils for this shape if supported.
+    /// </summary>
+    private ShapeUtils m_utils = null;
+
+    /// <summary>
     /// Native geometry instance.
     /// </summary>
     protected agxCollide.Geometry m_geometry = null;
@@ -138,6 +143,17 @@ namespace AgXUnity.Collide
     }
 
     /// <summary>
+    /// Returns already created or creates a new instance of the specific
+    /// shape utils given type of this shape.
+    /// </summary>
+    public ShapeUtils GetUtils()
+    {
+      if ( m_utils == null )
+        m_utils = ShapeUtils.Create( this );
+      return m_utils;
+    }
+
+    /// <summary>
     /// Creates native shape and geometry. Assigns material to the
     /// native geometry if material is present.
     /// </summary>
@@ -203,27 +219,27 @@ namespace AgXUnity.Collide
     }
 
     /// <summary>
+    /// "Forward" synchronize the transform when e.g., the game object
+    /// has been moved in the editor.
+    /// </summary>
+    protected virtual void SyncNativeTransform()
+    {
+      // Automatic synchronization if we have a parent.
+      if ( m_geometry != null && m_geometry.getRigidBody() == null )
+        m_geometry.setLocalTransform( new agx.AffineMatrix4x4( transform.rotation.ToHandedQuat(), transform.position.ToHandedVec3() ) );
+    }
+
+    /// <summary>
     /// "Back" synchronize of transforms given the simulation has
     /// updated the transforms.
     /// </summary>
-    private void SyncUnityTransform()
+    protected virtual void SyncUnityTransform()
     {
       if ( transform.parent == null && m_geometry != null ) {
         agx.AffineMatrix4x4 t = m_geometry.getTransform();
         transform.position = t.getTranslate().ToHandedVector3();
         transform.rotation = t.getRotate().ToHandedQuaternion();
       }
-    }
-
-    /// <summary>
-    /// "Forward" synchronize the transform when e.g., the game object
-    /// has been moved in the editor.
-    /// </summary>
-    private void SyncNativeTransform()
-    {
-      // Automatic synchronization if we have a parent.
-      if ( m_geometry != null && m_geometry.getRigidBody() == null )
-        m_geometry.setLocalTransform( new agx.AffineMatrix4x4( transform.rotation.ToHandedQuat(), transform.position.ToHandedVec3() ) );
     }
   }
 }

--- a/AgXUnity/Collide/ShapeUtils.cs
+++ b/AgXUnity/Collide/ShapeUtils.cs
@@ -1,0 +1,178 @@
+﻿using UnityEngine;
+
+namespace AgXUnity.Collide
+{
+  public class BoxShapeUtils : ShapeUtils
+  {
+    public override Vector3 GetLocalFace( Direction dir )
+    {
+      Box box = GetShape<Box>();
+      return Vector3.Scale( box.HalfExtents, GetLocalFaceDirection( dir ) );
+    }
+
+    public override bool IsHalfSize( Direction direction )
+    {
+      return true;
+    }
+
+    public override void UpdateSize( Vector3 localChange, Direction dir )
+    {
+      Box box = GetShape<Box>();
+      box.HalfExtents = box.HalfExtents + Vector3.Scale( GetLocalFaceDirection( dir ), localChange );
+    }
+  }
+
+  public class CapsuleShapeUtils : ShapeUtils
+  {
+    public override Vector3 GetLocalFace( Direction dir )
+    {
+      Capsule capsule = GetShape<Capsule>();
+      if ( ToPrincipal( dir ) == PrincipalAxis.Y )
+        return ( capsule.Radius + 0.5f * capsule.Height ) * GetLocalFaceDirection( dir );
+      else
+        return capsule.Radius * GetLocalFaceDirection( dir );
+    }
+
+    public override bool IsHalfSize( Direction direction )
+    {
+      return ToPrincipal( direction ) != PrincipalAxis.Y;
+    }
+
+    public override void UpdateSize( Vector3 localChange, Direction dir )
+    {
+      Capsule capsule = GetShape<Capsule>();
+      if ( ToPrincipal( dir ) == PrincipalAxis.Y )
+        capsule.Height = capsule.Height + Vector3.Dot( GetLocalFaceDirection( dir ), localChange );
+      else
+        capsule.Radius = capsule.Radius + Vector3.Dot( GetLocalFaceDirection( dir ), localChange );
+    }
+  }
+
+  public class CylinderShapeUtils : ShapeUtils
+  {
+    public override Vector3 GetLocalFace( Direction dir )
+    {
+      Cylinder capsule = GetShape<Cylinder>();
+      if ( ToPrincipal( dir ) == PrincipalAxis.Y )
+        return 0.5f * capsule.Height * GetLocalFaceDirection( dir );
+      else
+        return capsule.Radius * GetLocalFaceDirection( dir );
+    }
+
+    public override bool IsHalfSize( Direction direction )
+    {
+      return ToPrincipal( direction ) != PrincipalAxis.Y;
+    }
+
+    public override void UpdateSize( Vector3 localChange, Direction dir )
+    {
+      Cylinder cylinder = GetShape<Cylinder>();
+      if ( ToPrincipal( dir ) == PrincipalAxis.Y )
+        cylinder.Height = cylinder.Height + Vector3.Dot( GetLocalFaceDirection( dir ), localChange );
+      else
+        cylinder.Radius = cylinder.Radius + Vector3.Dot( GetLocalFaceDirection( dir ), localChange );
+    }
+  }
+
+  public class SphereShapeUtils : ShapeUtils
+  {
+    public override Vector3 GetLocalFace( Direction dir )
+    {
+      Sphere sphere = GetShape<Sphere>();
+      return sphere.Radius * GetLocalFaceDirection( dir );
+    }
+
+    public override bool IsHalfSize( Direction direction )
+    {
+      return true;
+    }
+
+    public override void UpdateSize( Vector3 localChange, Direction dir )
+    {
+      Sphere sphere = GetShape<Sphere>();
+      sphere.Radius = sphere.Radius + Vector3.Dot( GetLocalFaceDirection( dir ), localChange );
+    }
+  }
+
+  public abstract class ShapeUtils
+  {
+    public static ShapeUtils Create( Shape shape )
+    {
+      if ( shape is Box )
+        return new BoxShapeUtils() { m_shape = shape };
+      else if ( shape is Capsule )
+        return new CapsuleShapeUtils() { m_shape = shape };
+      else if ( shape is Cylinder )
+        return new CylinderShapeUtils() { m_shape = shape };
+      else if ( shape is Sphere )
+        return new SphereShapeUtils() { m_shape = shape };
+
+      return null;
+    }
+
+    public enum PrincipalAxis
+    {
+      X,
+      Y,
+      Z
+    }
+
+    public enum Direction
+    {
+      Positive_X,
+      Negative_X,
+      Positive_Y,
+      Negative_Y,
+      Positive_Z,
+      Negative_Z
+    }
+
+    public abstract Vector3 GetLocalFace( Direction direction );
+
+    public abstract bool IsHalfSize( Direction direction );
+
+    public abstract void UpdateSize( Vector3 localChange, Direction dir );
+
+    public Vector3 GetLocalFaceDirection( Direction direction )
+    {
+      return m_unitFaces[ System.Convert.ToInt32( direction ) ];
+    }
+
+    public Vector3 GetWorldFace( Direction direction )
+    {
+      return m_shape.transform.TransformPoint( GetLocalFace( direction ) );
+    }
+
+    public Vector3 GetWorldFaceDirection( Direction direction )
+    {
+      return m_shape.transform.TransformDirection( GetLocalFaceDirection( direction ) );
+    }
+
+    public PrincipalAxis ToPrincipal( Direction dir )
+    {
+      return (PrincipalAxis)( System.Convert.ToInt32( dir ) / 2 );
+    }
+
+    public float GetSign( Direction dir )
+    {
+      return 1.0f - 2.0f * ( System.Convert.ToInt32( dir ) % 2 );
+    }
+
+
+    public T GetShape<T>() where T : Shape
+    {
+      return m_shape as T;
+    }
+
+    private static Vector3[] m_unitFaces = new Vector3[]{
+                                                          new Vector3(  1,  0,  0 ),
+                                                          new Vector3( -1,  0,  0 ),
+                                                          new Vector3(  0,  1,  0 ),
+                                                          new Vector3(  0, -1,  0 ),
+                                                          new Vector3(  0,  0,  1 ),
+                                                          new Vector3(  0,  0, -1 )
+                                                        };
+
+    private Shape m_shape = null;
+  }
+}

--- a/AgXUnity/Collide/ShapeUtils.cs
+++ b/AgXUnity/Collide/ShapeUtils.cs
@@ -140,7 +140,7 @@ namespace AgXUnity.Collide
 
     public Vector3 GetWorldFace( Direction direction )
     {
-      return m_shape.transform.TransformPoint( GetLocalFace( direction ) );
+      return m_shape.transform.position + m_shape.transform.TransformDirection( GetLocalFace( direction ) );
     }
 
     public Vector3 GetWorldFaceDirection( Direction direction )

--- a/AgXUnity/Rendering/DebugRenderManager.cs
+++ b/AgXUnity/Rendering/DebugRenderManager.cs
@@ -52,6 +52,17 @@ namespace AgXUnity.Rendering
     }
 
     /// <summary>
+    /// Use when Collide.Mesh source objects is updated.
+    /// </summary>
+    public static void HandleMeshSource( Collide.Mesh mesh )
+    {
+      if ( !ActiveForSynchronize )
+        return;
+
+      Instance.SynchronizeShape( mesh );
+    }
+
+    /// <summary>
     /// Called on LateUpdate from shapes without rigid bodies.
     /// </summary>
     public static void OnLateUpdate( Collide.Shape shape )

--- a/AgXUnity/Simulation.cs
+++ b/AgXUnity/Simulation.cs
@@ -73,9 +73,9 @@ namespace AgXUnity
 
       var cameraData = new
       {
-        Eye               = Camera.main.transform.position,
-        Center            = Camera.main.transform.position + 25.0f * Camera.main.transform.forward,
-        Up                = Camera.main.transform.up,
+        Eye               = Camera.main.transform.position.ToHandedVec3().ToVector3(),
+        Center            = ( Camera.main.transform.position + 25.0f * Camera.main.transform.forward ).ToHandedVec3().ToVector3(),
+        Up                = Camera.main.transform.up.ToHandedVec3().ToVector3(),
         NearClippingPlane = Camera.main.nearClipPlane,
         FarClippingPlane  = Camera.main.farClipPlane,
         FOV               = Camera.main.fieldOfView

--- a/AgXUnityEditor/AgXUnityEditor.csproj
+++ b/AgXUnityEditor/AgXUnityEditor.csproj
@@ -47,6 +47,8 @@
     <Compile Include="Menus\AssetsMenu.cs" />
     <Compile Include="Menus\TopMenu.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tools\ShapeResizeTool.cs" />
+    <Compile Include="Tools\Tool.cs" />
     <Compile Include="Utils\AssetFactory.cs" />
     <Compile Include="Utils\GUIHelper.cs" />
     <Compile Include="Utils\Mesh.cs" />

--- a/AgXUnityEditor/Manager.cs
+++ b/AgXUnityEditor/Manager.cs
@@ -5,18 +5,51 @@ using AgXUnity.Utils;
 
 namespace AgXUnityEditor
 {
+  /// <summary>
+  /// Manager object, initialized when the Unity editor is loaded, to handle
+  /// all tools, behavior related etc. objects while in edit mode.
+  /// </summary>
   [InitializeOnLoad]
   public static class Manager
   {
+    /// <summary>
+    /// Constructor called when the Unity editor is initialized.
+    /// </summary>
     static Manager()
     {
       SceneView.onSceneGUIDelegate += OnSceneView;
     }
 
-    private static List<Tools.Tool> m_tools = new List<Tools.Tool>() { new Tools.ShapeResizeTool() };
+    /// <summary>
+    /// Callback from KeyHandler objects when constructed. The KeyCode has to be unique.
+    /// </summary>
+    public static void OnKeyHandlerConstruct( Utils.GUIHelper.KeyHandler handler )
+    {
+      if ( m_keyHandlers.ContainsKey( handler.Key ) ) {
+        Debug.LogWarning( "Key handler with key: " + handler.Key + " already registered. Ignoring handler." );
+        return;
+      }
+
+      m_keyHandlers.Add( handler.Key, handler );
+    }
+
+    private static Dictionary<KeyCode, Utils.GUIHelper.KeyHandler> m_keyHandlers = new Dictionary<KeyCode, Utils.GUIHelper.KeyHandler>();
+
+    private static List<Tools.Tool> m_tools = new List<Tools.Tool>()
+    {
+      new Tools.ShapeResizeTool()
+      {
+        ActivateKey       = new Utils.GUIHelper.KeyHandler( KeyCode.LeftControl ),
+        SymmetricScaleKey = new Utils.GUIHelper.KeyHandler( KeyCode.LeftShift )
+      }
+    };
 
     private static void OnSceneView( SceneView sceneView )
     {
+      Event current = Event.current;
+      foreach ( var keyHandler in m_keyHandlers.Values )
+        keyHandler.Update( current );
+
       var proxyTarget = Selection.activeGameObject != null ? Selection.activeGameObject.GetComponent<OnSelectionProxy>() : null;
       if ( proxyTarget != null )
         Selection.activeGameObject = proxyTarget.Target;

--- a/AgXUnityEditor/Manager.cs
+++ b/AgXUnityEditor/Manager.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 using UnityEditor;
 using AgXUnity.Utils;
 
@@ -12,11 +13,16 @@ namespace AgXUnityEditor
       SceneView.onSceneGUIDelegate += OnSceneView;
     }
 
+    private static List<Tools.Tool> m_tools = new List<Tools.Tool>() { new Tools.ShapeResizeTool() };
+
     private static void OnSceneView( SceneView sceneView )
     {
       var proxyTarget = Selection.activeGameObject != null ? Selection.activeGameObject.GetComponent<OnSelectionProxy>() : null;
       if ( proxyTarget != null )
         Selection.activeGameObject = proxyTarget.Target;
+
+      foreach ( var tool in m_tools )
+        tool.OnSceneViewGUI( sceneView );
 
       SceneView.RepaintAll();
     }

--- a/AgXUnityEditor/Tools/ShapeResizeTool.cs
+++ b/AgXUnityEditor/Tools/ShapeResizeTool.cs
@@ -1,0 +1,55 @@
+﻿using UnityEngine;
+using UnityEditor;
+using AgXUnity.Collide;
+
+namespace AgXUnityEditor.Tools
+{
+  public class ShapeResizeTool : Tool
+  {
+    public override void OnSceneViewGUI( SceneView sceneView )
+    {
+      if ( Selection.activeGameObject == null )
+        return;
+
+      Shape shape = Selection.activeGameObject.GetComponent<Shape>();
+      if ( shape == null )
+        return;
+
+      // Tool activated on control down.
+      // Symmetric mode if ctrl + shift is down.
+      bool activateKeyDown = Event.current.control;
+      if ( activateKeyDown )
+        Update( shape, Event.current.shift );
+    }
+
+    private void Update( Shape shape, bool symmetricScale )
+    {
+      if ( shape == null )
+        return;
+
+      ShapeUtils utils = shape.GetUtils();
+      if ( utils == null )
+        return;
+
+      Undo.RecordObject( shape, "ShapeResizeTool" );
+      Undo.RecordObject( shape.transform, "ShapeResizeToolTransform" );
+
+      Color color = Color.gray;
+      float scale = 0.35f;
+      foreach ( ShapeUtils.Direction dir in System.Enum.GetValues( typeof( ShapeUtils.Direction ) ) ) {
+        Vector3 delta = DeltaSliderTool( utils.GetWorldFace( dir ), utils.GetWorldFaceDirection( dir ), color, scale );
+        if ( delta.magnitude > 1.0E-5f ) {
+          Vector3 localSizeChange = shape.transform.InverseTransformDirection( delta );
+          Vector3 localPositionDelta = 0.5f * localSizeChange;
+          if ( !symmetricScale && utils.IsHalfSize( dir ) )
+            localSizeChange *= 0.5f;
+
+          utils.UpdateSize( localSizeChange, dir );
+
+          if ( !symmetricScale )
+            shape.transform.position += shape.transform.TransformVector( localPositionDelta );
+        }
+      }
+    }
+  }
+}

--- a/AgXUnityEditor/Tools/ShapeResizeTool.cs
+++ b/AgXUnityEditor/Tools/ShapeResizeTool.cs
@@ -4,8 +4,26 @@ using AgXUnity.Collide;
 
 namespace AgXUnityEditor.Tools
 {
+  /// <summary>
+  /// Tool to resize supported primitive shape types. Supported types
+  /// (normally Box, Capsule, Cylinder and Sphere) has ShapeUtils set.
+  /// 
+  /// This tool is active when ActiveKey is down and a supported shape
+  /// is selected. For symmetric resize, both SymmetricScaleKey and
+  /// ActiveKey has to be down.
+  /// </summary>
   public class ShapeResizeTool : Tool
   {
+    /// <summary>
+    /// Key code to activate this tool.
+    /// </summary>
+    public Utils.GUIHelper.KeyHandler ActivateKey { get; set; }
+
+    /// <summary>
+    /// Key code for symmetric scale/resize.
+    /// </summary>
+    public Utils.GUIHelper.KeyHandler SymmetricScaleKey { get; set; }
+
     public override void OnSceneViewGUI( SceneView sceneView )
     {
       if ( Selection.activeGameObject == null )
@@ -15,11 +33,8 @@ namespace AgXUnityEditor.Tools
       if ( shape == null )
         return;
 
-      // Tool activated on control down.
-      // Symmetric mode if ctrl + shift is down.
-      bool activateKeyDown = Event.current.control;
-      if ( activateKeyDown )
-        Update( shape, Event.current.shift );
+      if ( ActivateKey.IsDown )
+        Update( shape, SymmetricScaleKey.IsDown );
     }
 
     private void Update( Shape shape, bool symmetricScale )
@@ -47,7 +62,7 @@ namespace AgXUnityEditor.Tools
           utils.UpdateSize( localSizeChange, dir );
 
           if ( !symmetricScale )
-            shape.transform.position += shape.transform.TransformVector( localPositionDelta );
+            shape.transform.position += shape.transform.TransformDirection( localPositionDelta );
         }
       }
     }

--- a/AgXUnityEditor/Tools/Tool.cs
+++ b/AgXUnityEditor/Tools/Tool.cs
@@ -1,0 +1,150 @@
+﻿using UnityEngine;
+using UnityEditor;
+
+namespace AgXUnityEditor.Tools
+{
+  public class Tool
+  {
+    /// <summary>
+    /// Color of the x axis.
+    /// </summary>
+    /// <param name="alpha">Alpha value.</param>
+    /// <returns>Color of the x axis.</returns>
+    public static UnityEngine.Color GetXAxisColor( float alpha = 1.0f )
+    {
+      return new UnityEngine.Color( 1.0f, 0, 0, alpha );
+    }
+
+    /// <summary>
+    /// Color of the y axis.
+    /// </summary>
+    /// <param name="alpha">Alpha value.</param>
+    /// <returns>Color of the y axis.</returns>
+    public static UnityEngine.Color GetYAxisColor( float alpha = 1.0f )
+    {
+      return new UnityEngine.Color( 0, 1.0f, 0, alpha );
+    }
+
+    /// <summary>
+    /// Color of the z axis.
+    /// </summary>
+    /// <param name="alpha">Alpha value.</param>
+    /// <returns>Color of the z axis.</returns>
+    public static UnityEngine.Color GetZAxisColor( float alpha = 1.0f )
+    {
+      return new UnityEngine.Color( 0, 0, 1.0f, alpha );
+    }
+
+    /// <summary>
+    /// Color of the center.
+    /// </summary>
+    /// <param name="alpha">Alpha value.</param>
+    /// <returns>Color of the center.</returns>
+    public static UnityEngine.Color GetCenterColor( float alpha = 1.0f )
+    {
+      return new UnityEngine.Color( 0.7f, 0.7f, 0.7f, alpha );
+    }
+
+    /// <summary>
+    /// Creates a position tool given position and rotation.
+    /// </summary>
+    /// <param name="position">Current position.</param>
+    /// <param name="rotation">Current rotation.</param>
+    /// <param name="scale">Scale - default 1.0f.</param>
+    /// <param name="alpha">Alpha - default 1.0f.</param>
+    /// <returns>New position of the tool.</returns>
+    public static Vector3 PositionTool( Vector3 position, Quaternion rotation, float scale = 1.0f, float alpha = 1.0f )
+    {
+      Vector3 snapSetting = new Vector3( 0.5f, 0.5f, 0.5f );
+
+      Color orgColor = Handles.color;
+
+      float handleSize = HandleUtility.GetHandleSize( position );
+      Color color = Handles.color;
+      Handles.color = GetXAxisColor( alpha );
+      position = Handles.Slider( position, rotation * Vector3.right, scale * handleSize, new Handles.DrawCapFunction( Handles.ArrowCap ), snapSetting.x );
+      Handles.color = GetYAxisColor( alpha );
+      position = Handles.Slider( position, rotation * Vector3.up, scale * handleSize, new Handles.DrawCapFunction( Handles.ArrowCap ), snapSetting.y );
+      Handles.color = GetZAxisColor( alpha );
+      position = Handles.Slider( position, rotation * Vector3.forward, scale * handleSize, new Handles.DrawCapFunction( Handles.ArrowCap ), snapSetting.z );
+      Handles.color = GetCenterColor( 0.6f * alpha );
+      position = Handles.FreeMoveHandle( position, rotation, scale * handleSize * 0.15f, snapSetting, new Handles.DrawCapFunction( Handles.RectangleCap ) );
+
+      Handles.color = orgColor;
+
+      return position;
+    }
+
+    /// <summary>
+    /// Creates a rotation tool given position and rotation.
+    /// </summary>
+    /// <param name="position">Current position.</param>
+    /// <param name="rotation">Current rotation.</param>
+    /// <param name="scale">Scale - default 1.0f.</param>
+    /// <param name="alpha">Alpha - default 1.0f.</param>
+    /// <returns>New rotation of the tool.</returns>
+    public static Quaternion RotationTool( Vector3 position, Quaternion rotation, float scale = 1.0f, float alpha = 1.0f )
+    {
+      float snapSetting = 0.5f;
+
+      Color orgColor = Handles.color;
+
+      float handleSize = HandleUtility.GetHandleSize( position );
+      Color color = Handles.color;
+      Handles.color = GetXAxisColor( alpha );
+      rotation = Handles.Disc( rotation, position, rotation * Vector3.right, scale * handleSize, true, snapSetting );
+      Handles.color = GetYAxisColor( alpha );
+      rotation = Handles.Disc( rotation, position, rotation * Vector3.up, scale * handleSize, true, snapSetting );
+      Handles.color = GetZAxisColor( alpha );
+      rotation = Handles.Disc( rotation, position, rotation * Vector3.forward, scale * handleSize, true, snapSetting );
+      Handles.color = GetCenterColor( 0.6f * alpha );
+      rotation = Handles.Disc( rotation, position, Camera.current.transform.forward, scale * handleSize * 1.1f, false, 0f );
+      rotation = Handles.FreeRotateHandle( rotation, position, scale * handleSize );
+
+      Handles.color = orgColor;
+
+      return rotation;
+    }
+
+    /// <summary>
+    /// Creates single direction slider tool.
+    /// </summary>
+    /// <param name="position">Position of the slider.</param>
+    /// <param name="direction">Direction of the slider.</param>
+    /// <param name="color">Color of the slider.</param>
+    /// <param name="scale">Scale - default 1.0.</param>
+    /// <returns>New position of the slider.</returns>
+    public static Vector3 SliderTool( Vector3 position, Vector3 direction, Color color, float scale = 1.0f )
+    {
+      float snapSetting = 0.001f;
+
+      Color prevColor = Handles.color;
+      Handles.color = color;
+      float handleSize = HandleUtility.GetHandleSize( position );
+      position = Handles.Slider( position, direction, scale * handleSize, new Handles.DrawCapFunction( Handles.ArrowCap ), snapSetting );
+      Handles.color = prevColor;
+
+      return position;
+    }
+
+    /// <summary>
+    /// Creates a slider tool but instead of the new position this function returns the movement.
+    /// </summary>
+    /// <param name="position">Position of the slider.</param>
+    /// <param name="direction">Direction of the slider.</param>
+    /// <param name="color">Color of the slider.</param>
+    /// <param name="scale">Scale - default 1.0.</param>
+    /// <returns>How much the slider has been moved.</returns>
+    public static Vector3 DeltaSliderTool( Vector3 position, Vector3 direction, Color color, float scale = 1.0f )
+    {
+      Vector3 newPosition = SliderTool( position, direction, color, scale );
+      return newPosition - position;
+    }
+
+    public Tool()
+    {
+    }
+
+    public virtual void OnSceneViewGUI( SceneView sceneView ) { }
+  }
+}

--- a/AgXUnityEditor/Utils/GUIHelper.cs
+++ b/AgXUnityEditor/Utils/GUIHelper.cs
@@ -85,5 +85,46 @@ namespace AgXUnityEditor.Utils
 
       return texture;
     }
+
+    /// <summary>
+    /// Handles when specific key is down/pressed during GUI event loop.
+    /// </summary>
+    public class KeyHandler
+    {
+      /// <summary>
+      /// Key to check if pressed.
+      /// </summary>
+      public KeyCode Key { get; set; }
+
+      /// <summary>
+      /// True if the given key is down - otherwise false.
+      /// </summary>
+      public bool IsDown { get; private set; }
+
+      /// <summary>
+      ///  Default constructor.
+      /// </summary>
+      /// <param name="key">Key to handle.</param>
+      public KeyHandler( KeyCode key )
+      {
+        Key = key;
+        IsDown = false;
+        Manager.OnKeyHandlerConstruct( this );
+      }
+
+      /// <summary>
+      /// Update given current event. This method is automatically
+      /// called during GUI update.
+      /// </summary>
+      public void Update( Event current )
+      {
+        if ( Key == KeyCode.LeftShift || Key == KeyCode.RightShift )
+          IsDown = current.shift;
+        else if ( current.type == EventType.KeyDown && Key == current.keyCode )
+          IsDown = true;
+        else if ( current.type == EventType.KeyUp && Key == current.keyCode )
+          IsDown = false;
+      }
+    }
   }
 }


### PR DESCRIPTION
Shape resize tool, activate by selecting a shape in the SceneView and hold CTRL. For symmetric resizing hold CTRL + SHIFT. "Slider handles" appears on each face of the shape. Supported shapes: Box, Capsule, Cylinder and Sphere. Mesh supports scale from gameObject.transform so no need to have a tool for that. Also hard to implement.

Bug fixed when HeightField were created from Terrain. HeightField shapes are no assumed to be static. Easy to implement support for moving height fields. UnityEngine.Terrain doesn't support rotation.
