### PR TITLE
Controlled update order

### DIFF
--- a/AgXUnity/AgXUnity.csproj
+++ b/AgXUnity/AgXUnity.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Rendering\PickHandlerRenderer.cs" />
     <Compile Include="Rendering\SegmentSpawner.cs" />
     <Compile Include="Rendering\SpawnerUtils.cs" />
+    <Compile Include="StepCallbackFunctions.cs" />
     <Compile Include="Utils\ConstraintUtils.cs" />
     <Compile Include="Utils\DisposableCallback.cs" />
     <Compile Include="Utils\InvokeWrapper.cs" />

--- a/AgXUnity/Collide/Shape.cs
+++ b/AgXUnity/Collide/Shape.cs
@@ -189,7 +189,7 @@ namespace AgXUnity.Collide
       //}
 
       // TODO: Add pre-synch to be able to move geometries during play?
-      Simulation.Instance.PostSynchronizeTransforms += PostSynchronizeTransformsCallback;
+      Simulation.Instance.StepCallbacks.PostSynchronizeTransforms += OnPostSynchronizeTransformsCallback;
 
       return base.Initialize();
     }
@@ -203,7 +203,7 @@ namespace AgXUnity.Collide
         GetSimulation().remove( m_geometry );
 
       if ( Simulation.Instance != null )
-        Simulation.Instance.PostSynchronizeTransforms -= PostSynchronizeTransformsCallback;
+        Simulation.Instance.StepCallbacks.PostSynchronizeTransforms -= OnPostSynchronizeTransformsCallback;
 
       if ( m_shape != null )
         m_shape.Dispose();
@@ -220,13 +220,13 @@ namespace AgXUnity.Collide
     /// Late update call from Unity where stepForward can
     /// be assumed to be done.
     /// </summary>
-    private void PostSynchronizeTransformsCallback()
+    private void OnPostSynchronizeTransformsCallback()
     {
       SyncUnityTransform();
 
       // If we have a body the debug rendering synchronization is made from that body.
       if ( m_geometry != null && m_geometry.getRigidBody() == null )
-        Rendering.DebugRenderManager.OnLateUpdate( this );
+        Rendering.DebugRenderManager.OnPostSynchronizeTransforms( this );
     }
 
     /// <summary>

--- a/AgXUnity/Collide/Shape.cs
+++ b/AgXUnity/Collide/Shape.cs
@@ -188,6 +188,9 @@ namespace AgXUnity.Collide
       //  m_geometry.getPropertyContainer().addPropertyBool( "Pulley", true );
       //}
 
+      // TODO: Add pre-synch to be able to move geometries during play?
+      Simulation.Instance.PostSynchronizeTransforms += PostSynchronizeTransformsCallback;
+
       return base.Initialize();
     }
 
@@ -198,6 +201,9 @@ namespace AgXUnity.Collide
     {
       if ( m_geometry != null && GetSimulation() != null )
         GetSimulation().remove( m_geometry );
+
+      if ( Simulation.Instance != null )
+        Simulation.Instance.PostSynchronizeTransforms -= PostSynchronizeTransformsCallback;
 
       if ( m_shape != null )
         m_shape.Dispose();
@@ -214,7 +220,7 @@ namespace AgXUnity.Collide
     /// Late update call from Unity where stepForward can
     /// be assumed to be done.
     /// </summary>
-    protected void LateUpdate()
+    private void PostSynchronizeTransformsCallback()
     {
       SyncUnityTransform();
 

--- a/AgXUnity/Constraint.cs
+++ b/AgXUnity/Constraint.cs
@@ -279,7 +279,7 @@ namespace AgXUnity
 
         bool valid = added && Native.getValid();
         if ( valid )
-          Simulation.Instance.PreSynchronizeTransforms += PreStepForwardUpdate;
+          Simulation.Instance.StepCallbacks.PreSynchronizeTransforms += OnPreStepForwardUpdate;
 
         return valid;
       }
@@ -292,7 +292,7 @@ namespace AgXUnity
     protected override void OnDestroy()
     {
       if ( GetSimulation() != null ) {
-        Simulation.Instance.PreSynchronizeTransforms -= PreStepForwardUpdate;
+        Simulation.Instance.StepCallbacks.PreSynchronizeTransforms -= OnPreStepForwardUpdate;
         GetSimulation().remove( Native );
       }
 
@@ -301,7 +301,7 @@ namespace AgXUnity
       base.OnDestroy();
     }
 
-    private void PreStepForwardUpdate()
+    private void OnPreStepForwardUpdate()
     {
       if ( Native == null )
         return;

--- a/AgXUnity/Constraint.cs
+++ b/AgXUnity/Constraint.cs
@@ -277,7 +277,11 @@ namespace AgXUnity
           CollisionGroupsManager.Instance.GetInitialized<CollisionGroupsManager>().SetEnablePair( groupName, groupName, false );
         }
 
-        return added && Native.getValid();
+        bool valid = added && Native.getValid();
+        if ( valid )
+          Simulation.Instance.PreSynchronizeTransforms += PreStepForwardUpdate;
+
+        return valid;
       }
       catch ( System.Exception e ) {
         Debug.LogException( e, gameObject );
@@ -287,18 +291,18 @@ namespace AgXUnity
 
     protected override void OnDestroy()
     {
-      if ( GetSimulation() != null )
+      if ( GetSimulation() != null ) {
+        Simulation.Instance.PreSynchronizeTransforms -= PreStepForwardUpdate;
         GetSimulation().remove( Native );
+      }
 
       Native = null;
 
       base.OnDestroy();
     }
 
-    protected void FixedUpdate()
+    private void PreStepForwardUpdate()
     {
-      // TODO: Implement event pre/post etc in Simulation. This update has to be before stepForward.
-
       if ( Native == null )
         return;
 

--- a/AgXUnity/PickHandler.cs
+++ b/AgXUnity/PickHandler.cs
@@ -197,8 +197,16 @@ namespace AgXUnity
     private MouseButtonState m_mouseButtonState = new MouseButtonState();
     private float m_distanceFromCamera = -1f;
 
+    protected override void OnEnable()
+    {
+      Simulation.Instance.PreCallbacks += PreStepForwardCallback;
+    }
+
     protected override void OnDisable()
     {
+      if ( Simulation.HasInstance )
+        Simulation.Instance.PreCallbacks -= PreStepForwardCallback;
+
       if ( ConstraintGameObject != null )
         Destroy( ConstraintGameObject );
       ConstraintGameObject = null;
@@ -210,7 +218,7 @@ namespace AgXUnity
       m_mouseButtonState.Update( Event.current, Input.GetKey( TriggerKey ) );
     }
 
-    private void FixedUpdate()
+    private void PreStepForwardCallback()
     {
       Camera camera = Camera.main;
       if ( camera == null )

--- a/AgXUnity/PickHandler.cs
+++ b/AgXUnity/PickHandler.cs
@@ -199,13 +199,13 @@ namespace AgXUnity
 
     protected override void OnEnable()
     {
-      Simulation.Instance.PreCallbacks += PreStepForwardCallback;
+      Simulation.Instance.StepCallbacks.PreStepForward += OnPreStepForwardCallback;
     }
 
     protected override void OnDisable()
     {
       if ( Simulation.HasInstance )
-        Simulation.Instance.PreCallbacks -= PreStepForwardCallback;
+        Simulation.Instance.StepCallbacks.PreStepForward -= OnPreStepForwardCallback;
 
       if ( ConstraintGameObject != null )
         Destroy( ConstraintGameObject );
@@ -218,7 +218,7 @@ namespace AgXUnity
       m_mouseButtonState.Update( Event.current, Input.GetKey( TriggerKey ) );
     }
 
-    private void PreStepForwardCallback()
+    private void OnPreStepForwardCallback()
     {
       Camera camera = Camera.main;
       if ( camera == null )

--- a/AgXUnity/Rendering/DebugRenderData.cs
+++ b/AgXUnity/Rendering/DebugRenderData.cs
@@ -40,7 +40,7 @@ namespace AgXUnity.Rendering
 
     /// <summary>
     /// Callback from the DebugRenderManager each editor "Update" or
-    /// in "LateUpdate" when the application is running.
+    /// after each simulation step when the application is running.
     /// 
     /// Synchronize the transform of the "Node" game object - create the "Node"
     /// instance if it's null.

--- a/AgXUnity/Rendering/DebugRenderManager.cs
+++ b/AgXUnity/Rendering/DebugRenderManager.cs
@@ -68,9 +68,9 @@ namespace AgXUnity.Rendering
     }
 
     /// <summary>
-    /// Called on LateUpdate from shapes without rigid bodies.
+    /// Called after Simulation.StepForward from shapes without rigid bodies.
     /// </summary>
-    public static void OnLateUpdate( Collide.Shape shape )
+    public static void OnPostSynchronizeTransforms( Collide.Shape shape )
     {
       if ( !ActiveForSynchronize )
         return;
@@ -79,9 +79,9 @@ namespace AgXUnity.Rendering
     }
 
     /// <summary>
-    /// Called on LateUpdate from bodies to synchronize debug rendering of the shapes.
+    /// Called after Simulation.StepForward from bodies to synchronize debug rendering of the shapes.
     /// </summary>
-    public static void OnLateUpdate( RigidBody rb )
+    public static void OnPostSynchronizeTransforms( RigidBody rb )
     {
       if ( !ActiveForSynchronize )
         return;

--- a/AgXUnity/Rendering/PickHandlerRenderer.cs
+++ b/AgXUnity/Rendering/PickHandlerRenderer.cs
@@ -32,6 +32,7 @@ namespace AgXUnity.Rendering
                                                   sphereRadius,
                                                   true );
 
+      // TODO: Handle when reference frame position == connected frame position.
       Rendering.Spawner.Utils.SetCylinderTransform( ConnectingCylinder,
                                                     constraint.AttachmentPair.ReferenceFrame.Position,
                                                     constraint.AttachmentPair.ConnectedFrame.Position,

--- a/AgXUnity/Rendering/WireRenderer.cs
+++ b/AgXUnity/Rendering/WireRenderer.cs
@@ -16,6 +16,12 @@ namespace AgXUnity.Rendering
 
     public float NumberOfSegmentsPerMeter = 2.0f;
 
+    public void OnPostStepForward( Wire wire )
+    {
+      if ( wire != null )
+        Render( wire );
+    }
+
     protected override bool Initialize()
     {
       InitializeRenderer( true );
@@ -32,16 +38,19 @@ namespace AgXUnity.Rendering
       base.OnDestroy();
     }
 
+    /// <summary>
+    /// Catching LateUpdate calls since ExecuteInEditMode attribute.
+    /// </summary>
     protected void LateUpdate()
     {
-      Wire wire = GetComponent<Wire>();
-      if ( wire == null )
+      // During play we're receiving callbacks from the wire
+      // to OnPostStepForward.
+      if ( Application.isPlaying )
         return;
 
-      if ( !Application.isPlaying && wire.Native == null )
+      Wire wire = GetComponent<Wire>();
+      if ( wire != null && wire.Native == null )
         RenderRoute( wire.Route, wire.Radius );
-      else
-        Render( wire );
     }
 
     private void RenderRoute( WireRoute route, float radius )

--- a/AgXUnity/RigidBody.cs
+++ b/AgXUnity/RigidBody.cs
@@ -246,20 +246,24 @@ namespace AgXUnity
 
       UpdateMassProperties();
 
+      Simulation.Instance.PostSynchronizeTransforms += PostSynchronizeTransformsCallback;
+
       return base.Initialize();
     }
 
     protected override void OnDestroy()
     {
-      if ( GetSimulation() != null )
+      if ( GetSimulation() != null ) {
+        Simulation.Instance.PostSynchronizeTransforms -= PostSynchronizeTransformsCallback;
         GetSimulation().remove( m_rb );
+      }
 
       m_rb = null;
 
       base.OnDestroy();
     }
 
-    protected void LateUpdate()
+    private void PostSynchronizeTransformsCallback()
     {
       SyncUnityTransform();
       SyncProperties();
@@ -296,6 +300,7 @@ namespace AgXUnity
 
     private void SyncProperties()
     {
+      // TODO: If "get" has native we can return the current velocity? Still possible to set.
       if ( m_rb == null )
         return;
 

--- a/AgXUnity/RigidBody.cs
+++ b/AgXUnity/RigidBody.cs
@@ -246,7 +246,7 @@ namespace AgXUnity
 
       UpdateMassProperties();
 
-      Simulation.Instance.PostSynchronizeTransforms += PostSynchronizeTransformsCallback;
+      Simulation.Instance.StepCallbacks.PostSynchronizeTransforms += OnPostSynchronizeTransformsCallback;
 
       return base.Initialize();
     }
@@ -254,7 +254,7 @@ namespace AgXUnity
     protected override void OnDestroy()
     {
       if ( GetSimulation() != null ) {
-        Simulation.Instance.PostSynchronizeTransforms -= PostSynchronizeTransformsCallback;
+        Simulation.Instance.StepCallbacks.PostSynchronizeTransforms -= OnPostSynchronizeTransformsCallback;
         GetSimulation().remove( m_rb );
       }
 
@@ -263,12 +263,12 @@ namespace AgXUnity
       base.OnDestroy();
     }
 
-    private void PostSynchronizeTransformsCallback()
+    private void OnPostSynchronizeTransformsCallback()
     {
       SyncUnityTransform();
       SyncProperties();
 
-      Rendering.DebugRenderManager.OnLateUpdate( this );
+      Rendering.DebugRenderManager.OnPostSynchronizeTransforms( this );
     }
     #endregion
 

--- a/AgXUnity/Simulation.cs
+++ b/AgXUnity/Simulation.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using AgXUnity.Utils;
+﻿using AgXUnity.Utils;
 using UnityEngine;
 
 namespace AgXUnity
@@ -63,12 +62,12 @@ namespace AgXUnity
     /// </summary>
     public agxSDK.Simulation Native { get { return GetOrCreateSimulation(); } }
 
-    public delegate void StepCallbackFunction();
+    private StepCallbackFunctions m_stepCallbackFunctions = new StepCallbackFunctions();
 
-    public StepCallbackFunction PreCallbacks;
-    public StepCallbackFunction PreSynchronizeTransforms;
-    public StepCallbackFunction PostSynchronizeTransforms;
-    public StepCallbackFunction PostCallbacks;
+    /// <summary>
+    /// Step callback interface. Valid use from "initialize" to "Destroy".
+    /// </summary>
+    public StepCallbackFunctions StepCallbacks { get { return m_stepCallbackFunctions; } }
 
     protected override bool Initialize()
     {
@@ -80,8 +79,8 @@ namespace AgXUnity
     protected void FixedUpdate()
     {
       if ( m_simulation != null ) {
-        PreCallbacks?.Invoke();
-        PreSynchronizeTransforms?.Invoke();
+        StepCallbacks.PreStepForward?.Invoke();
+        StepCallbacks.PreSynchronizeTransforms?.Invoke();
 
         agx.Timer t = new agx.Timer( true );
         
@@ -90,8 +89,8 @@ namespace AgXUnity
         t.stop();
         m_stepForwardTime = t.getTime();
 
-        PostSynchronizeTransforms?.Invoke();
-        PostCallbacks?.Invoke();
+        StepCallbacks.PostSynchronizeTransforms?.Invoke();
+        StepCallbacks.PostStepForward?.Invoke();
       }
     }
 

--- a/AgXUnity/Simulation.cs
+++ b/AgXUnity/Simulation.cs
@@ -1,4 +1,5 @@
-﻿using AgXUnity.Utils;
+﻿using System.Linq;
+using AgXUnity.Utils;
 using UnityEngine;
 
 namespace AgXUnity
@@ -14,7 +15,6 @@ namespace AgXUnity
     /// Native instance.
     /// </summary>
     private agxSDK.Simulation m_simulation = null;
-
     private double m_stepForwardTime = 0.0;
 
     /// <summary>
@@ -41,7 +41,7 @@ namespace AgXUnity
     /// Time step size is the default callback frequency in Unity.
     /// </summary>
     [SerializeField]
-    float m_timeStep = 1.0f / 50.0f;
+    private float m_timeStep = 1.0f / 50.0f;
 
     /// <summary>
     /// Get or set time step size. Note that the time step has to
@@ -56,6 +56,73 @@ namespace AgXUnity
         if ( m_simulation != null )
           m_simulation.setTimeStep( m_timeStep );
       }
+    }
+
+    /// <summary>
+    /// Get the native instance, if not deleted.
+    /// </summary>
+    public agxSDK.Simulation Native { get { return GetOrCreateSimulation(); } }
+
+    public delegate void StepCallbackFunction();
+
+    public StepCallbackFunction PreCallbacks;
+    public StepCallbackFunction PreSynchronizeTransforms;
+    public StepCallbackFunction PostSynchronizeTransforms;
+    public StepCallbackFunction PostCallbacks;
+
+    protected override bool Initialize()
+    {
+      GetOrCreateSimulation();
+
+      return base.Initialize();
+    }
+
+    protected void FixedUpdate()
+    {
+      if ( m_simulation != null ) {
+        PreCallbacks?.Invoke();
+        PreSynchronizeTransforms?.Invoke();
+
+        agx.Timer t = new agx.Timer( true );
+        
+        m_simulation.stepForward();
+
+        t.stop();
+        m_stepForwardTime = t.getTime();
+
+        PostSynchronizeTransforms?.Invoke();
+        PostCallbacks?.Invoke();
+      }
+    }
+
+    protected void OnGUI()
+    {
+      GUILayout.Label( "Step forward time: " + m_stepForwardTime + " ms." );
+      GUILayout.Label( "Step forward FPS:  " + (int)( 1000.0 / m_stepForwardTime + 0.5 ) );
+      GUILayout.Label( "Update frequencey: " + (int)( 1.0f / Time.fixedDeltaTime ) );
+    }
+
+    protected override void OnApplicationQuit()
+    {
+      base.OnApplicationQuit();
+      if ( m_simulation != null )
+        m_simulation.cleanup();
+    }
+
+    protected override void OnDestroy()
+    {
+      base.OnDestroy();
+      if ( m_simulation != null )
+        m_simulation.cleanup();
+      m_simulation = null;
+    }
+
+    private agxSDK.Simulation GetOrCreateSimulation()
+    {
+      if ( m_simulation == null )
+        m_simulation = new agxSDK.Simulation();
+
+      return m_simulation;
     }
 
     [InvokableInInspector( "Open in AgX native viewer" )]
@@ -116,60 +183,6 @@ end";
       System.IO.File.WriteAllText( path + tmpLuaFilename, luaFileContent );
 
       System.Diagnostics.Process.Start( "luaagx.exe", path + tmpLuaFilename+ " -p --renderDebug 1" );
-    }
-
-    /// <summary>
-    /// Get the native instance, if not deleted.
-    /// </summary>
-    public agxSDK.Simulation Native { get { return GetOrCreateSimulation(); } }
-
-    protected override bool Initialize()
-    {
-      GetOrCreateSimulation();
-
-      return base.Initialize();
-    }
-
-    protected void FixedUpdate()
-    {
-      if ( m_simulation != null ) {
-        agx.Timer t = new agx.Timer( true );
-        
-        m_simulation.stepForward();
-
-        t.stop();
-        m_stepForwardTime = t.getTime();
-      }
-    }
-
-    protected void OnGUI()
-    {
-      GUILayout.Label( "Step forward time: " + m_stepForwardTime + " ms." );
-      GUILayout.Label( "Step forward FPS:  " + (int)( 1000.0 / m_stepForwardTime + 0.5 ) );
-      GUILayout.Label( "Update frequencey: " + (int)( 1.0f / Time.fixedDeltaTime ) );
-    }
-
-    protected override void OnApplicationQuit()
-    {
-      base.OnApplicationQuit();
-      if ( m_simulation != null )
-        m_simulation.cleanup();
-    }
-
-    protected override void OnDestroy()
-    {
-      base.OnDestroy();
-      if ( m_simulation != null )
-        m_simulation.cleanup();
-      m_simulation = null;
-    }
-
-    private agxSDK.Simulation GetOrCreateSimulation()
-    {
-      if ( m_simulation == null )
-        m_simulation = new agxSDK.Simulation();
-
-      return m_simulation;
     }
   }
 }

--- a/AgXUnity/StepCallbackFunctions.cs
+++ b/AgXUnity/StepCallbackFunctions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace AgXUnity
+{
+  /// <summary>
+  /// Simulation step callback functions.
+  /// </summary>
+  public class StepCallbackFunctions
+  {
+    /// <summary>
+    /// Step callback signature: void callback()
+    /// </summary>
+    public delegate void StepCallbackDef();
+
+    /// <summary>
+    /// Before native simulation.stepForward is called. This callback is
+    /// fired before the native transforms are written so feel free to
+    /// change and use Unity object transforms.
+    /// </summary>
+    public StepCallbackDef PreStepForward;
+
+    /// <summary>
+    /// After PreStepForward, before native simulation.stepForward is called.
+    /// Synchronize all native transforms during this callback.
+    /// </summary>
+    public StepCallbackDef PreSynchronizeTransforms;
+
+    /// <summary>
+    /// Callback after native simulation.stepForward is done and before any
+    /// other post callbacks. Write back transforms from the simulation to
+    /// the Unity objects during this call.
+    /// </summary>
+    public StepCallbackDef PostSynchronizeTransforms;
+
+    /// <summary>
+    /// After PostSynchronizeTransforms where the Unity objects have the
+    /// transforms of the simulation step. During this callback it's possible
+    /// to use "all" data from the simulation.
+    /// </summary>
+    public StepCallbackDef PostStepForward;
+  }
+}

--- a/AgXUnity/Wire.cs
+++ b/AgXUnity/Wire.cs
@@ -237,6 +237,7 @@ namespace AgXUnity
         }
 
         GetSimulation().add( Native );
+        Simulation.Instance.StepCallbacks.PostStepForward += OnPostStepForward;
       }
       catch ( System.Exception e ) {
         Debug.LogException( e, this );
@@ -246,22 +247,27 @@ namespace AgXUnity
       return Native.initialized();
     }
 
-    protected void LateUpdate()
-    {
-      if ( BeginWinch != null )
-        BeginWinch.OnLateUpdate();
-      if ( EndWinch != null )
-        EndWinch.OnLateUpdate();
-    }
-
     protected override void OnDestroy()
     {
-      if ( GetSimulation() != null )
+      if ( GetSimulation() != null ) {
         GetSimulation().remove( Native );
+        Simulation.Instance.StepCallbacks.PostStepForward -= OnPostStepForward;
+      }
 
       Native = null;
 
       base.OnDestroy();
+    }
+
+    private void OnPostStepForward()
+    {
+      GetComponent<Rendering.WireRenderer>().OnPostStepForward( this );
+
+      if ( BeginWinch != null )
+        BeginWinch.OnPostStepForward( this );
+
+      if ( EndWinch != null )
+        EndWinch.OnPostStepForward( this );
     }
   }
 }

--- a/AgXUnity/WireWinch.cs
+++ b/AgXUnity/WireWinch.cs
@@ -107,7 +107,7 @@ namespace AgXUnity
       return true;
     }
 
-    public void OnLateUpdate()
+    public void OnPostStepForward( Wire wire )
     {
       if ( Native != null )
         m_pulledInLength = Convert.ToSingle( Native.getPulledInWireLength() );

--- a/AgXUnityEditor/Manager.cs
+++ b/AgXUnityEditor/Manager.cs
@@ -290,12 +290,25 @@ namespace AgXUnityEditor
     private static void UpdateMouseOverPrimitives( Event current )
     {
       // Can't perform picking during repaint event.
-      if ( current == null || !(current.isMouse || current.isKey) )
+      if ( current == null || !( current.isMouse || current.isKey ) )
         return;
 
       // Update mouse over before we reveal the VisualPrimitives.
-      if ( current.isMouse )
-        MouseOverObject = RouteObject( HandleUtility.PickGameObject( current.mousePosition, false ) ) as GameObject;
+      // NOTE: We're putting our "visual primitives" in the ignore list.
+      if ( current.isMouse ) {
+        List<GameObject> ignoreList = new List<GameObject>();
+        foreach ( var primitive in m_visualPrimitives ) {
+          if ( !primitive.Visible )
+            continue;
+
+          MeshFilter[] primitiveFilters = primitive.Node.GetComponentsInChildren<MeshFilter>();
+          ignoreList.AddRange( primitiveFilters.Select( pf => { return pf.gameObject; } ) );
+        }
+
+        MouseOverObject = RouteObject( HandleUtility.PickGameObject( current.mousePosition,
+                                                                     false,
+                                                                     ignoreList.ToArray() ) ) as GameObject;
+      }
 
       // Early exit if we haven't any active visual primitives.
       if ( m_visualPrimitives.Count == 0 )

--- a/AgXUnityEditor/Utils/VisualPrimitive.cs
+++ b/AgXUnityEditor/Utils/VisualPrimitive.cs
@@ -195,8 +195,6 @@ namespace AgXUnityEditor.Utils
   {
     public void SetTransform( Vector3 position, Quaternion rotation, Vector3 scale, bool constantScreenSize = true )
     {
-      // TODO: Mouse over isn't working. It only highlights cylinder or top?
-
       if ( Node == null )
         return;
 


### PR DESCRIPTION
Update events during runtime to bodies, shapes, constraints, wires etc., in the following order:
1. Pre-step forward
2. Pre-step forward update transforms (e.g., write Unity transforms to native objects)
3. Simulation STEP FORWARD
4. Post-step forward update transforms (e.g., read native transforms back to Unity)
5. Post-step forward
