### PR TITLE
Store cable and wire routes.

### DIFF
--- a/AgXUnityEditor/AgXUnityEditor.csproj
+++ b/AgXUnityEditor/AgXUnityEditor.csproj
@@ -47,6 +47,8 @@
     <Compile Include="EditorData.cs" />
     <Compile Include="EditorDataEntry.cs" />
     <Compile Include="EditorSettings.cs" />
+    <Compile Include="Legacy\CableRouteData.cs" />
+    <Compile Include="Legacy\WireRouteData.cs" />
     <Compile Include="Manager.cs" />
     <Compile Include="Menus\AssetsMenu.cs" />
     <Compile Include="Menus\TopMenu.cs" />

--- a/AgXUnityEditor/EditorDataEntry.cs
+++ b/AgXUnityEditor/EditorDataEntry.cs
@@ -28,6 +28,8 @@ namespace AgXUnityEditor
     private float m_float = 0f;
     [SerializeField]
     private string m_string = string.Empty;
+    [SerializeField]
+    private ScriptableObject m_scriptableObject = null;
 
     public bool Bool
     {
@@ -85,6 +87,17 @@ namespace AgXUnityEditor
       }
     }
 
+    public ScriptableObject ScriptableObject
+    {
+      get { return m_scriptableObject; }
+      set
+      {
+        m_scriptableObject = value;
+
+        OnValueChanged();
+      }
+    }
+
     public uint Key { get { return m_key; } private set { m_key = value; } }
 
     public int InstanceId { get { return m_instanceId; } private set { m_instanceId = value; } }
@@ -98,6 +111,11 @@ namespace AgXUnityEditor
         InstanceId = target.GetInstanceID();
       else
         m_isStatic = true;
+    }
+
+    public void SetIsStatic( bool isStatic )
+    {
+      m_isStatic = isStatic;
     }
 
     private void OnValueChanged()

--- a/AgXUnityEditor/Legacy/CableRouteData.cs
+++ b/AgXUnityEditor/Legacy/CableRouteData.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using AgXUnity;
+
+namespace AgXUnityEditor.Legacy
+{
+  [Serializable]
+  public class CableRouteNodeData
+  {
+    [SerializeField]
+    public Cable.NodeType NodeType = Cable.NodeType.BodyFixedNode;
+    [SerializeField]
+    public GameObject Parent = null;
+    [SerializeField]
+    public Vector3 LocalPosition = Vector3.zero;
+    [SerializeField]
+    public Quaternion LocalRotation = Quaternion.identity;
+  }
+
+  public class CableRouteData : ScriptableObject
+  {
+    [SerializeField]
+    private List<CableRouteNodeData> m_data = new List<CableRouteNodeData>();
+
+    public static CableRouteData Create( CableRoute cableRoute )
+    {
+      return CreateInstance<CableRouteData>().Construct( cableRoute );
+    }
+
+    public CableRouteData Construct( CableRoute wireRoute )
+    {
+      m_data.Clear();
+
+      foreach ( var node in wireRoute ) {
+        m_data.Add( new CableRouteNodeData()
+        {
+          NodeType = node.Type,
+          Parent = node.Frame.Parent,
+          LocalPosition = node.Frame.LocalPosition,
+          LocalRotation = node.Frame.LocalRotation,
+        } );
+      }
+
+      return this;
+    }
+  }
+}

--- a/AgXUnityEditor/Legacy/WireRouteData.cs
+++ b/AgXUnityEditor/Legacy/WireRouteData.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using AgXUnity;
+
+namespace AgXUnityEditor.Legacy
+{
+  [Serializable]
+  public class WireRouteWinchData
+  {
+    [SerializeField]
+    public float Speed = 0.0f;
+    [SerializeField]
+    public float PulledInLength = 0.0f;
+    [SerializeField]
+    public RangeReal ForceRange = new RangeReal();
+    [SerializeField]
+    public RangeReal BrakeForceRange = new RangeReal() { Min = 0.0f, Max = 0.0f };
+  }
+
+  [Serializable]
+  public class WireRouteNodeData
+  {
+    [SerializeField]
+    public Wire.NodeType NodeType = Wire.NodeType.BodyFixedNode;
+    [SerializeField]
+    public GameObject Parent = null;
+    [SerializeField]
+    public Vector3 LocalPosition = Vector3.zero;
+    [SerializeField]
+    public Quaternion LocalRotation = Quaternion.identity;
+    [SerializeField]
+    public WireRouteWinchData WinchData = null;
+  }
+
+  public class WireRouteData : ScriptableObject
+  {
+    [SerializeField]
+    private List<WireRouteNodeData> m_data = new List<WireRouteNodeData>();
+
+    public static WireRouteData Create( WireRoute wireRoute )
+    {
+      return CreateInstance<WireRouteData>().Construct( wireRoute );
+    }
+
+    public WireRouteData Construct( WireRoute wireRoute )
+    {
+      m_data.Clear();
+
+      foreach ( var node in wireRoute ) {
+        m_data.Add( new WireRouteNodeData()
+        {
+          NodeType      = node.Type,
+          Parent        = node.Frame.Parent,
+          LocalPosition = node.Frame.LocalPosition,
+          LocalRotation = node.Frame.LocalRotation,
+          WinchData     = node.Type == Wire.NodeType.WinchNode ?
+                          new WireRouteWinchData()
+                          {
+                            Speed = node.Winch.Speed,
+                            PulledInLength = node.Winch.PulledInLength,
+                            ForceRange = node.Winch.ForceRange,
+                            BrakeForceRange = node.Winch.BrakeForceRange
+                          } :
+                          null
+        } );
+      }
+
+      return this;
+    }
+  }
+}

--- a/AgXUnityEditor/Manager.cs
+++ b/AgXUnityEditor/Manager.cs
@@ -217,7 +217,7 @@ namespace AgXUnityEditor
       GameObject.DestroyImmediate( primitive.Node );
     }
 
-    public static void SaveWireCableRoutesToEditorData()
+    public static void SaveWireCableRoutesToEditorData( bool silent = false )
     {
       {
         AgXUnity.Wire[] wires = UnityEngine.Object.FindObjectsOfType<AgXUnity.Wire>();
@@ -227,7 +227,8 @@ namespace AgXUnityEditor
           data.ScriptableObject = data.ScriptableObject is Legacy.WireRouteData ?
                                     ( data.ScriptableObject as Legacy.WireRouteData ).Construct( wire.Route ) :
                                     Legacy.WireRouteData.Create( wire.Route );
-          Debug.Log( "Saved data for wire route.", wire );
+          if ( !silent )
+            Debug.Log( "Saved data for wire route.", wire );
         }
       }
 
@@ -239,7 +240,8 @@ namespace AgXUnityEditor
           data.ScriptableObject = data.ScriptableObject is Legacy.CableRouteData ?
                                     ( data.ScriptableObject as Legacy.CableRouteData ).Construct( cable.Route ) :
                                     Legacy.CableRouteData.Create( cable.Route );
-          Debug.Log( "Saved data for cable route.", cable );
+          if ( !silent )
+            Debug.Log( "Saved data for cable route.", cable );
         }
       }
     }
@@ -467,6 +469,8 @@ namespace AgXUnityEditor
               selectionProxy.Component = wire;
           }
         }
+
+        SaveWireCableRoutesToEditorData( true );
       }
     }
 

--- a/AgXUnityEditor/Manager.cs
+++ b/AgXUnityEditor/Manager.cs
@@ -217,6 +217,33 @@ namespace AgXUnityEditor
       GameObject.DestroyImmediate( primitive.Node );
     }
 
+    public static void SaveWireCableRoutesToEditorData()
+    {
+      {
+        AgXUnity.Wire[] wires = UnityEngine.Object.FindObjectsOfType<AgXUnity.Wire>();
+        foreach ( var wire in wires ) {
+          var data = EditorData.Instance.GetData( wire, "WireRouteData" );
+          data.SetIsStatic( true );
+          data.ScriptableObject = data.ScriptableObject is Legacy.WireRouteData ?
+                                    ( data.ScriptableObject as Legacy.WireRouteData ).Construct( wire.Route ) :
+                                    Legacy.WireRouteData.Create( wire.Route );
+          Debug.Log( "Saved data for wire route.", wire );
+        }
+      }
+
+      {
+        AgXUnity.Cable[] cables = UnityEngine.Object.FindObjectsOfType<AgXUnity.Cable>();
+        foreach ( var cable in cables ) {
+          var data = EditorData.Instance.GetData( cable, "CableRouteData" );
+          data.SetIsStatic( true );
+          data.ScriptableObject = data.ScriptableObject is Legacy.CableRouteData ?
+                                    ( data.ScriptableObject as Legacy.CableRouteData ).Construct( cable.Route ) :
+                                    Legacy.CableRouteData.Create( cable.Route );
+          Debug.Log( "Saved data for cable route.", cable );
+        }
+      }
+    }
+
     private static string m_currentSceneName = string.Empty;
     private static bool m_requestSceneViewFocus = false;
     private static HijackLeftMouseClickData m_hijackLeftMouseClickData = null;

--- a/AgXUnityEditor/Menus/TopMenu.cs
+++ b/AgXUnityEditor/Menus/TopMenu.cs
@@ -288,6 +288,12 @@ namespace AgXUnityEditor
     {
       Utils.CustomEditorGenerator.Generate();
     }
+
+    [MenuItem( "AgXUnity/Utils/Save Wire and Cable routes future version" ) ]
+    public static void SaveWireCableRoutesForFutureVersion()
+    {
+      Manager.SaveWireCableRoutesToEditorData();
+    }
     #endregion
   }
 }


### PR DESCRIPTION
Storing data for cable and wire routes to be used in future version where ScriptableObject/ScriptAsset references are removed.